### PR TITLE
Remove service generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ZooBC installation script based on bashscript for help user to install ZooBC nod
 
 ## How To
 1. You can clone this repo or just download the raw format.
-   <br>via curl: `curl https://raw.githubusercontent.com/zoobc/zoobc-installer/remove-service-generator/installer.sh -o installer.sh` and also make sure the file permission `chmod +x installer.sh`
+   <br>via curl: `curl https://raw.githubusercontent.com/zoobc/zoobc-installer/master/installer.sh -o installer.sh` and also make sure the file permission `chmod +x installer.sh`
 2. Copy the certificate file `wallet.zbc` on the same directory with the `installer.sh` file.
    - Upload to server:
        - scp: `scp wallet.zbc {user}@{ip_address}:/{installation_path}`
@@ -29,8 +29,8 @@ ZooBC installation script based on bashscript for help user to install ZooBC nod
 The script will create directory `zoobc.{target}` on the `$HOME`. There are several files:
 ```sh
 ~/zoobc
-├── zoobc
-├── cmd
+├── zoobc #binary
+├── cmd #binary
 ├── config.toml
 └── resource
     ├── node_keys.json
@@ -39,4 +39,4 @@ The script will create directory `zoobc.{target}` on the `$HOME`. There are seve
 ## Compatibility
 - [x] MacOS
 - [x] Linux
-- [ ] Windows 
+- [x] Windows 

--- a/README.md
+++ b/README.md
@@ -4,27 +4,39 @@ ZooBC installation script based on bashscript for help user to install ZooBC nod
 
 ## How To
 1. You can clone this repo or just download the raw format.
-   <br>via curl: `curl https://raw.githubusercontent.com/zoobc/zoobc-installer/master/installer.sh -o installer.sh` and also make sure the file permission `chmod +x installer.sh`
+   <br>via curl: `curl https://raw.githubusercontent.com/zoobc/zoobc-installer/remove-service-generator/installer.sh -o installer.sh` and also make sure the file permission `chmod +x installer.sh`
 2. Copy the certificate file `wallet.zbc` on the same directory with the `installer.sh` file.
    - Upload to server:
        - scp: `scp wallet.zbc {user}@{ip_address}:/{installation_path}`
 3. Run installation script:
     <br>`./installer.sh`
 4. To run the node:
-   - Daemon start:
-      - MacOS: `launchctl load /Library/LaunchDaemons/org.zoobc.startup.plist`
-      - Linux: `service zoobc start`
-   - Daemon stop:
-      - MacOS: `launchctl unload /Library/LaunchDaemons/org.zoobc.startup.plist`
-      - Linux: `service zoobc stop`
+   - **Install daemon**:
+      - sudo ./zoobc daemon install
+   - **Start Daemon**:
+      - `sudo ./zoobc daemon start`
+   - **Stop Daemon**:
+      - `sudo ./zoobc daemon stop`
+    - **Status Daemon**:
+      - `sudo ./zoobc daemon status`
     - Run binary file:
       - `cd $HOME/zoobc.{dev|staging|alpha|beta}`
-      - `./zoobc`
+      - `./zoobc run`
     - Stop binary file:
       - kill process `CTRL+c`
-> The script will create directory `zoobc.{target}` on the `$HOME`.
 
-## Compatiibility
+## Result
+The script will create directory `zoobc.{target}` on the `$HOME`. There are several files:
+```sh
+~/zoobc
+├── zoobc
+├── cmd
+├── config.toml
+└── resource
+    ├── node_keys.json
+```
+
+## Compatibility
 - [x] MacOS
 - [x] Linux
 - [ ] Windows 

--- a/installer.sh
+++ b/installer.sh
@@ -65,85 +65,6 @@ function download_binary() {
   chmod 755 "$(get_dir_target)/$zbc_cmd_binary"
 }
 
-# generate_service will generate service script to systemd called zoobc.service
-function generate_service() {
-  echo 'Generating daemon service ...'
-  case $(get_platform) in
-  'linux')
-    if [ ! -f "/lib/systemd/system/zoobc.service" ]; then
-      cat >zoobc.service <<EOF
-[Unit]
-Description=zoobc node service
-[Service]
-Type=simple
-User=root
-Group=root
-#emergency (0), alert (1), critical (2), error (3), warning (4), notice (5), info (6), and debug (6)
-LogLevelMax=3
-WorkingDirectory=$HOME/$(get_dir_target)
-ExecStart=$HOME/zoobc/zoobc --debug --cpu-profile
-Restart=on-failure
-RestartSec=3
-
-[Install]
-WantedBy=multi-user.target
-EOF
-      sudo cp zoobc.service /lib/systemd/system/zoobc.service
-      systemctl daemon-reload
-    fi
-    ;;
-  'darwin')
-    if [ ! -f /Library/LaunchDaemons/org.zoobc.startup.plist ]; then
-      cat >org.zoobc.startup.plist <<EOF
-<?xml version"1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key>
-  <string>org.zoobc.startup</string>
-  <key>ServiceDescription</key>
-  <string>ZOOBC NODE Service zoobc.com</string>
-  <key>WorkingDirectory</key>
-  <string>$HOME/$(get_dir_target)</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>./zoobc</string>
-  </array>
-  <key>UserName</key>
-  <string>root</string>
-  <key>GroupName</key>
-  <string>root</string>
-  <key>RunAtLoad</key>
-  <true/>
-  <key>KeepAlive</key>
-  <true/>
-</dict>
-</plist>
-EOF
-      sudo cp org.zoobc.startup.plist /Library/LaunchDaemons
-    fi
-    ;;
-  *)
-    echo "For $(get_platform) please check on zoobc.com for more detail"
-    ;;
-  esac
-}
-
-function start_service() {
-  echo "Starting Service ..."
-  case $(get_platform) in
-  'darwin')
-    launchctl load /Library/LaunchDaemons/org.zoobc.startup.plist
-    ;;
-  'linux')
-    service zoobc start
-    ;;
-  *)
-    echo "For $(get_platform) please check on zoobc.com for more detail"
-    ;;
-  esac
-}
-
 ################
 # MAIN PROCESS #
 ################
@@ -159,18 +80,8 @@ if [[ $target =~ dev|staging|alpha|beta ]]; then
     download_binary
   then
     cd "$(get_dir_target)" && ./$zbc_cmd_binary configure -t="$target"
-    generate_service
     echo "Installation finish."
-    case $(get_platform) in
-    'linux')
-      echo "To running daemon: service zoobc start"
-      ;;
-    'darwin')
-      echo "To running daemon: launchctl load /Library/LaunchDaemons/org.zoobc.startup.plist"
-      ;;
-    *) ;;
-    esac
-    echo "Or running manually: cd $(get_dir_target) && ./$zbc_binary"
+    echo "How to run: cd $(get_dir_target) && ./$zbc_binary run"
   fi
 else
   echo 'usage: sh ./installer.sh dev|staging|alpha|beta'


### PR DESCRIPTION
Since the [`zoobc`](https://github.com/zoobc/zoobc-core) already has command to running via daemon which means it doesn't need a script to have service generator.